### PR TITLE
fix: update maintainer information in Dockerfile and clean up docker-…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ ARG ROS_DISTRO=jazzy
 FROM ros:${ROS_DISTRO}
 
 # Set the maintainer information for this Dockerfile
-LABEL maintainer="AutomaticAddison<automatic_addison@todo.com>"
+LABEL maintainer="MaxDomitrovic<max@domitrovic.com>"
 
 # Set environment variables
 ENV PIP_BREAK_SYSTEM_PACKAGES=1

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,8 @@
-version: '3.3'
 services:
   manipulation: &manipulation
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile
     container_name: manipulation
     image: manipulation:latest
     ipc: host
@@ -23,19 +25,3 @@ services:
       - /dev/gpiomem:/dev/gpiomem
       - /dev/mem:/dev/mem
     command: ["tail", "-f", "/dev/null"]
-
-  # The following services are commented out for this tutorial.
-  # They demonstrate how to create multiple containers from the same Docker image,
-  # each running a specific ROS 2 node. These containers can communicate with each other
-  # because they share the same ROS_DOMAIN_ID.
-  # Publisher service: Runs the demo talker node
-  minimal_publisher:
-    <<: *manipulation  # This uses all the same settings as the 'manipulation' service
-    container_name: minimal_publisher
-    command: ["ros2", "run", "demo_nodes_cpp", "talker"]
-
-  # Subscriber service: Runs the demo listener node
-  minimal_subscriber:
-    <<: *manipulation  # This uses all the same settings as the 'manipulation' service
-    container_name: minimal_subscriber
-    command: ["ros2", "run", "demo_nodes_cpp", "listener"]


### PR DESCRIPTION
This pull request updates the Docker configuration for the project, focusing on revising maintainer information, improving the `docker-compose.yml` file, and removing unused services.

### Updates to Docker configuration:

* **Maintainer information updated**: The `LABEL maintainer` field in the `docker/Dockerfile` was updated to reflect a new maintainer, changing from "AutomaticAddison" to "MaxDomitrovic".

* **Build context added in `docker-compose.yml`**: The `manipulation` service now specifies a build context and Dockerfile path, enabling the service to be built directly from the `docker/Dockerfile`.

### Cleanup of unused services:

* **Removed unused ROS 2 services**: The `minimal_publisher` and `minimal_subscriber` services, which were commented out and served as examples for creating multiple containers, were removed from the `docker-compose.yml` file. This simplifies the configuration by eliminating unused code.…compose.yml