### PR TITLE
feat: add Lidar support to bridge_node.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /.ros
 /.ssh
 /.vscode-server
+/.vscode
 /.local
 /build
 /install

--- a/ros2_ws/src/custom_msgs/CMakeLists.txt
+++ b/ros2_ws/src/custom_msgs/CMakeLists.txt
@@ -1,8 +1,14 @@
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.5)
 project(custom_msgs)
 
+find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/VehicleCommand.msg"
+  "msg/Command.msg"
 )
+
+ament_export_dependencies(rosidl_default_runtime)
+
+ament_package()

--- a/ros2_ws/src/custom_msgs/package.xml
+++ b/ros2_ws/src/custom_msgs/package.xml
@@ -1,22 +1,17 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>custom_msgs</name>
   <version>0.0.0</version>
   <description>Custom messages for vehicle control.</description>
   <maintainer email="max@domitrovic.com">root</maintainer>
-  <license>TODO: License declaration</license>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
-  <build_depend>message_generation</build_depend>
-  <exec_depend>rosidl_default_runtime</exec_depend>
-  <exec_depend>message_runtime</exec_depend>
 
-  <test_depend>ament_copyright</test_depend>
-  <test_depend>ament_flake8</test_depend>
-  <test_depend>ament_pep257</test_depend>
-  <test_depend>python3-pytest</test_depend>
+  <build_depend>rosidl_default_generators</build_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
   <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>

--- a/ros2_ws/src/ros2_bridge/ros2_bridge/bridge_node.py
+++ b/ros2_ws/src/ros2_bridge/ros2_bridge/bridge_node.py
@@ -22,6 +22,7 @@ Run a ROS2 node that hosts a WebSocket server to bridge commands from external c
 import json
 import threading
 import time
+
 import RPi.GPIO as GPIO
 
 from custom_msgs.msg import VehicleCommand
@@ -30,6 +31,8 @@ import rclpy
 from rclpy.node import Node
 
 from websocket_server import WebsocketServer
+
+from sensor_msgs.msg import LaserScan
 
 
 def patch_websocket_server():
@@ -103,6 +106,13 @@ class ROSBridge(Node):
             target=self.run_websocket_server, daemon=True
         )
         self.websocket_thread.start()
+        self.lidar_subscriber = self.create_subscription(
+            LaserScan,
+            'scan',
+            self.lidar_callback,
+            10
+        )
+        self.clients = []
 
     def run_websocket_server(self):
         """Start the WebSocket server in an infinite loop so that it restarts upon any error."""
@@ -110,11 +120,11 @@ class ROSBridge(Node):
         while True:
             try:
                 self.get_logger().info('WebSocket server running on port 9090...')
-                server = WebsocketServer(host='0.0.0.0', port=9090)
-                server.set_fn_new_client(self.on_new_client)
-                server.set_fn_message_received(self.websocket_handler)
-                server.set_fn_client_left(self.on_client_disconnect)
-                server.run_forever()
+                self.server = WebsocketServer(host='0.0.0.0', port=9090)
+                self.server.set_fn_new_client(self.on_new_client)
+                self.server.set_fn_message_received(self.websocket_handler)
+                self.server.set_fn_client_left(self.on_client_disconnect)
+                self.server.run_forever()
             except Exception as e:
                 self.get_logger().error(f'WebSocket error: {e}')
                 self.get_logger().info('Restarting WebSocket server in 5 seconds...')
@@ -126,6 +136,7 @@ class ROSBridge(Node):
             if client is None:
                 self.get_logger().warning('An unknown client has connected.')
                 return
+            self.clients.append(client)
             self.get_logger().info(
                 f'New WebSocket client connected: {client.get("id", "unknown")}'
             )
@@ -138,6 +149,8 @@ class ROSBridge(Node):
             if client is None:
                 self.get_logger().warning('An unknown client disconnected.')
                 return
+            if client in self.clients:
+                self.clients.remove(client)
             self.get_logger().info(
                 f'WebSocket client {client.get("id", "unknown")} has disconnected.'
             )
@@ -209,6 +222,44 @@ class ROSBridge(Node):
                 self.get_logger().warning(f'Unknown command type: {cmd}')
         except Exception as e:
             self.get_logger().error(f'Error processing message: {e}')
+
+    def lidar_callback(self, msg):
+        """
+        Forward lidar data as JSON to all connected WebSocket clients.
+
+        Parameters:
+            msg (object): A message object (typically of type sensor_msgs.msg.LaserScan)
+                containing lidar data. The object is expected to have:
+                - header.stamp.sec (int): The seconds part of the timestamp.
+                - header.stamp.nanosec (int): The nanoseconds part of the timestamp.
+                - angle_min (float): The minimum angle of the scan.
+                - angle_max (float): The maximum angle of the scan.
+                - angle_increment (float): The angular increment between consecutive measurements.
+                - ranges (Iterable[float]): The range measurements from the lidar sensor.
+                - intensities (Iterable[float]): The intensity values corresponding to each range reading.
+
+        Raises:
+            Exception: If there is an error sending the JSON message to any client,
+                the exception is caught and an error message is logged.
+
+        Returns:
+            None
+        """
+        data = {
+            'timestamp': msg.header.stamp.sec + msg.header.stamp.nanosec * 1e-9,
+            'angle_min': msg.angle_min,
+            'angle_max': msg.angle_max,
+            'angle_increment': msg.angle_increment,
+            'ranges': list(msg.ranges),
+            'intensities': list(msg.intensities),
+        }
+        json_data = json.dumps({'lidar': data})
+
+        for client in self.clients:
+            try:
+                self.server.send_message(client, json_data)
+            except Exception as e:
+                self.get_logger().error(f"Error sending to client {client.get('id', 'unknown')}: {e}")
 
 
 def main(args=None):


### PR DESCRIPTION
This pull request introduces several updates to the ROS 2 workspace, focusing on improving the `custom_msgs` package and enhancing the `bridge_node.py` functionality. Key changes include updates to the custom message package configuration, the addition of a lidar subscriber, and WebSocket server enhancements to handle multiple clients and forward lidar data.

### Updates to the `custom_msgs` package:

* Updated `CMakeLists.txt` to include `ament_cmake` as a required package, added a new message type (`Command.msg`), and integrated `ament_package` for proper ROS 2 package handling.
* Modified `package.xml` to declare the `Apache-2.0` license, remove unused dependencies, and align with ROS 2 conventions by using `rosidl_default_runtime` and `rosidl_default_generators`.

### Enhancements to `bridge_node.py`:

* Added a `LaserScan` message subscription to process and forward lidar data via WebSocket to connected clients. This includes a new `lidar_callback` method to convert lidar data into JSON format and send it to all clients. [[1]](diffhunk://#diff-a4cb1214da2e7b8daa324136e959b4aeeef9fbbc430d17d55fac941381a74914R109-R127) [[2]](diffhunk://#diff-a4cb1214da2e7b8daa324136e959b4aeeef9fbbc430d17d55fac941381a74914R226-R263)
* Improved WebSocket server functionality by maintaining a list of connected clients (`self.clients`) and handling client connections and disconnections more robustly. [[1]](diffhunk://#diff-a4cb1214da2e7b8daa324136e959b4aeeef9fbbc430d17d55fac941381a74914R139) [[2]](diffhunk://#diff-a4cb1214da2e7b8daa324136e959b4aeeef9fbbc430d17d55fac941381a74914R152-R153)
* Introduced necessary imports for `LaserScan` messages and ensured proper organization of imports in the file. [[1]](diffhunk://#diff-a4cb1214da2e7b8daa324136e959b4aeeef9fbbc430d17d55fac941381a74914R25) [[2]](diffhunk://#diff-a4cb1214da2e7b8daa324136e959b4aeeef9fbbc430d17d55fac941381a74914R35-R36)