### PR TITLE
fix: correct qos_profile argument in CarController initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.bash_history
 /.cache
 /.colcon
 /.dotnet

--- a/ros2_ws/src/car_controller/car_controller/controller_node.py
+++ b/ros2_ws/src/car_controller/car_controller/controller_node.py
@@ -119,7 +119,7 @@ class CarController(Node):
             VehicleCommand,
             'vehicle_command',
             self.command_callback,
-            qos_profile
+            qos_profile,
             10
         )
         self.get_logger().info('CarController node started.')

--- a/ros2_ws/src/ros2_bridge/ros2_bridge/bridge_node.py
+++ b/ros2_ws/src/ros2_bridge/ros2_bridge/bridge_node.py
@@ -27,10 +27,6 @@ import RPi.GPIO as GPIO
 
 from custom_msgs.msg import VehicleCommand
 
-import RPi.GPIO as GPIO
-
-from custom_msgs.msg import VehicleCommand
-
 import rclpy
 from rclpy.node import Node
 


### PR DESCRIPTION
This pull request includes minor updates to the `CarController` and `ROS2Bridge` nodes to improve code consistency and cleanup unused imports.

### Changes to `CarController`:

* Updated the `create_subscription` method in `controller_node.py` to include an additional `10` parameter, likely specifying the queue size for the subscription.

### Changes to `ROS2Bridge`:

* Removed unused imports (`RPi.GPIO` and a duplicate `VehicleCommand` import) from `bridge_node.py` to clean up the code.